### PR TITLE
Move NODE_PATH from .env to build commands

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,1 @@
-NODE_PATH=src/
 REACT_APP_API_ENDPOINT=http://localhost:4000/api/v1


### PR DESCRIPTION
NODE_PATH is risky to put in .env as the build scripts break if a
NODE_PATH is already declared in an environment.

NODE_PATH makinada tanımlıysa tüm build scriptleri patlıyor.
Çok saçma ve böyle olmaması lazım, nitekim ofisyal react-scripts
doclarında .env içinde NODE_PATH kullanmaya dair hiç bir öneri
yok:
https://facebook.github.io/create-react-app/docs/adding-custom-environment-variables

İlgili bir issueda buna dair bir uyarı var:
https://github.com/facebook/create-react-app/issues/4928#issuecomment-422008734

Özetle bu bir hack ve tüm geliştiricilerden varsa kendi sistemlerinde
tanımlı NODE_PATH değişkenini kaldırmasını bekleyemeyiz.

.env içinden kaldırdım ve build scriptlerinin başına aldım.

Bu şekilde daha çirkin duruyor, ama:
1. Her zaman çalışıyor olması güzellikten daha önemli
2. Zaten react-scripts'ten de uygun zamanda kurtulmak lazım,
    o yüzden çok önemli değil.

NODE_PATH'e yaslanmadan proje rootundan require etmek için
alternatif teknikler de paylaşayım meraklısı için:
https://joelgriffith.net/share-server-and-client-javascript-the-node-way/
https://github.com/tleunen/babel-plugin-module-resolver