### PR TITLE
Un-ignore and start tracking .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+REACT_APP_API_ENDPOINT=http://dev.factlist.com/api/v1

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,4 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .idea
-.env
 run.sh


### PR DESCRIPTION
According to the recommendation in react-scripts docs:

> .env files should be checked into source control (with the exclusion of
> .env*.local).

https://facebook.github.io/create-react-app/docs/adding-custom-environment-variables#adding-development-environment-variables-in-env

.env'in default olarak mevcut olmaması projenin yüklenir
yüklenmez çalışmasının önüne geçiyor. .env.development'ın
kopyalanması ve .env olarak yaratılması ve editlenmesi lazım
falan filan. Bu süreç ise dokümante edilmemiş.

Öte yandan buna aslında gerek yok; zira react-scripts .envin
commit edilmesini tavsiye ediyor. İsteyen herkes kendi
ortamında .env.local ile bunu override edebilir:
https://facebook.github.io/create-react-app/docs/adding-custom-environment-variables#what-other-env-files-can-be-used