### PR TITLE
Add a linter script and config to lint manually

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "react-app"
+}

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "lint": "eslint src"
   }
 }


### PR DESCRIPTION
react-scripts lint automatically while building development
bundles and print the output but linting manually from one's
editor should be possible for better developer experience.

I shouldn't have to start a building process nor switch to the
relevant terminal window just to lint a single file.