### PR TITLE
Kill config and introduce a request wrapper

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,3 +1,0 @@
-export default ({
-  API_ENDPOINT: process.env.REACT_APP_API_ENDPOINT
-})

--- a/src/modules/auth/sagas/signIn.js
+++ b/src/modules/auth/sagas/signIn.js
@@ -1,7 +1,6 @@
 import { put } from 'redux-saga/effects'
 import { startSubmit, stopSubmit } from 'redux-form'
-import config from 'config'
-import axios from 'axios'
+import request from 'utils/request'
 import jwtDecode from 'jwt-decode';
 import { push as redirect } from 'react-router-redux'
 import { saveToken, saveUser } from 'utils/storage'
@@ -15,9 +14,10 @@ const signIn = function* ({ email, password }) {
   try {
     yield put(startSubmit(SIGN_IN_FORM_NAME))
 
-    // Token request with email & password
-    const response = yield axios
-      .post(`${config.API_ENDPOINT}/auth/login/`, { email, password })
+    const response = yield request('/auth/login', {
+      method: 'post',
+      data: {email, password},
+    })
 
     const { token } = response.data;
 

--- a/src/modules/auth/sagas/signInWithToken.js
+++ b/src/modules/auth/sagas/signInWithToken.js
@@ -1,6 +1,5 @@
 import { put } from 'redux-saga/effects'
-import config from 'config'
-import axios from 'axios'
+import request from 'utils/request'
 import { showNotification } from 'modules/notification/actions'
 import { saveToken } from 'utils/storage'
 import { signInSuccess, signInFailure } from '../actions'
@@ -8,10 +7,8 @@ import { signInSuccess, signInFailure } from '../actions'
 const signInWithToken = function* ({ token }) {
   try {
     // Get user's info with token
-    const response = yield axios.get(`${config.API_ENDPOINT}/auth/me/`, {
-      headers: {
-        Authorization: `Token ${token}`,
-      }
+    const response = yield request('/auth/me', {
+      headers: {Authorization: 'Token ' + token},
     })
 
     yield put(signInSuccess({

--- a/src/modules/auth/sagas/signInWithTwitter.js
+++ b/src/modules/auth/sagas/signInWithTwitter.js
@@ -1,13 +1,12 @@
 import { put } from 'redux-saga/effects'
-import config from 'config'
-import axios from 'axios'
+import request from 'utils/request'
 import { showNotification } from 'modules/notification/actions'
 import { closeModal } from 'modules/modal/actions'
 
 const signInWithTwitter = function* () {
   try {
     // Token request with email & password
-    const response = yield axios.get(`${config.API_ENDPOINT}/auth/twitter/`)
+    const response = yield request('/auth/twitter')
     const redirectURL = response.data.redirect_link
 
     // Redirect to Twitter

--- a/src/modules/embed/saga.js
+++ b/src/modules/embed/saga.js
@@ -1,6 +1,5 @@
 import { takeEvery, fork, select, put, call, all } from 'redux-saga/effects'
-import config from 'config'
-import axios from 'axios'
+import request from 'utils/request'
 import { FETCH_EMBED_REQUEST } from './constants'
 import {
   embedFetched,
@@ -17,10 +16,8 @@ const fetch = function* (id, url) {
   try {
     const token = yield select(state => state.auth.token)
 
-    const { data } = yield axios.get(`${config.API_ENDPOINT}/embed/?link=${url}`, {
-      headers: {
-        Authorization: `Token ${token}`,
-      }
+    const { data } = yield request('/embed/?link=' + url, {
+        headers: {Authorization: 'Token ' + token},
     })
 
     yield put(embedFetched({ id, url, data }))

--- a/src/modules/graphql/index.js
+++ b/src/modules/graphql/index.js
@@ -3,10 +3,9 @@ import { createHttpLink } from 'apollo-link-http';
 import { setContext } from 'apollo-link-context';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import { getToken } from 'utils/storage';
-import config from 'config'
 
 const httpLink = createHttpLink({
-  uri: `${config.API_ENDPOINT}/graphql`,
+  uri: process.env.REACT_APP_API_ENDPOINT + '/graphql',
   credentials: 'same-origin',
 });
 

--- a/src/modules/user/sagas/changePassword.js
+++ b/src/modules/user/sagas/changePassword.js
@@ -1,7 +1,6 @@
 import { put } from 'redux-saga/effects'
 import { startSubmit, stopSubmit } from 'redux-form'
-import config from 'config'
-import axios from 'axios'
+import request from 'utils/request'
 import formatFormErrors from 'utils/formatFormErrors'
 import { showNotification } from 'modules/notification/actions'
 import { CHANGE_PASSWORD_FORM } from '../constants'
@@ -13,9 +12,12 @@ const changePassword = function* (action) {
   try {
     yield put(startSubmit(CHANGE_PASSWORD_FORM))
 
-    yield axios.post(`${config.API_ENDPOINT}/auth/change_password/`, {
-      key: changeKey,
-      password,
+    yield request('/auth/change_password', {
+        method: 'post',
+        data: {
+            key: changeKey,
+            password,
+        },
     })
 
     yield put(stopSubmit(CHANGE_PASSWORD_FORM))

--- a/src/modules/user/sagas/forgotPassword.js
+++ b/src/modules/user/sagas/forgotPassword.js
@@ -1,7 +1,6 @@
 import { put } from 'redux-saga/effects'
 import { stopSubmit, startSubmit } from 'redux-form'
-import config from 'config'
-import axios from 'axios'
+import request from 'utils/request'
 import formatFormErrors from 'utils/formatFormErrors'
 import { showNotification } from 'modules/notification/actions'
 import { closeModal } from 'modules/modal/actions'
@@ -14,8 +13,9 @@ const forgotPassword = function* (action) {
 
     yield put(startSubmit(FORGOT_PASSWORD_FORM))
 
-    yield axios.post(`${config.API_ENDPOINT}/auth/reset-password/`, {
-      user_identifier: email,
+    yield request('/auth/reset-password', {
+      method: 'post',
+      data: {user_identifier: email},
     })
 
     yield put(stopSubmit(FORGOT_PASSWORD_FORM))

--- a/src/modules/user/sagas/signUp.js
+++ b/src/modules/user/sagas/signUp.js
@@ -1,6 +1,5 @@
 import { put } from 'redux-saga/effects'
-import axios from 'axios'
-import config from 'config'
+import request from 'utils/request'
 import formatFormErrors from 'utils/formatFormErrors'
 import { push as redirect } from 'react-router-redux'
 import { stopSubmit, startSubmit } from 'redux-form'
@@ -13,7 +12,10 @@ const signUp = function* (action) {
   try {
     yield put(startSubmit(SIGN_UP_FORM_NAME))
 
-    const response = yield axios.post(`${config.API_ENDPOINT}/auth/register/`, action.data)
+    const response = yield request('/auth/register', {
+      method: 'post',
+      data: action.data,
+    })
     const { token } = response.data
 
     yield put(signUpSuccess())

--- a/src/modules/user/sagas/update.js
+++ b/src/modules/user/sagas/update.js
@@ -1,7 +1,6 @@
 import { select, put } from 'redux-saga/effects'
-import axios from 'axios'
 import { stopSubmit, startSubmit } from 'redux-form'
-import config from 'config'
+import request from 'utils/request'
 import { showNotification } from 'modules/notification/actions'
 import { UPDATE_USER_FORM_NAME } from '../constants'
 import { userUpdated } from '../actions'
@@ -24,10 +23,10 @@ const update = function* (action) {
     const token = yield select(state => state.auth.token)
 
     // API request
-    const response = yield axios.patch(`${config.API_ENDPOINT}/auth/me/`, formData, {
-      headers: {
-        Authorization: `Token ${token}`
-      }
+    const response = yield request('/auth/me', {
+      method: 'patch',
+      data: formData,
+      headers: {Authorization: 'Token ' + token},
     })
 
     yield put(stopSubmit(UPDATE_USER_FORM_NAME))

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -1,0 +1,6 @@
+import axios from 'axios'
+
+export default (path, conf) => axios({
+    ...conf,
+    url: process.env.REACT_APP_API_ENDPOINT + path,
+})


### PR DESCRIPTION
It doesn't make sense to have a config file that imports the
API_ENDPOINT from another config file. One configuration is
sufficient.

Also referencing API_ENDPOINT in every single request is
unnecessary verbosity when it can be abstracted away with a simple
request wrapper.