### PR TITLE
Fix feather icon importing to cut bundle size

### DIFF
--- a/src/components/Topic/Menu/index.js
+++ b/src/components/Topic/Menu/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { withState } from 'recompose'
 import Popover from 'react-tiny-popover'
 import Nav from './Nav'
-import { MoreHorizontal } from 'react-feather'
+import MoreHorizontal from 'react-feather/dist/icons/more-horizontal'
 import styled from 'styled-components'
 
 const enhance = withState('isOpen', 'setIsOpen', false)


### PR DESCRIPTION
Either react-scripts don't support tree-shaking or react-feather
don't support it out of the box.

Until we fix that; we need to import icons directly from the
corresponding file to avoid importing the whole react-feather
library.

Bu güncelleme production bundle boyutunu 1.44 MB'tan
1.14 MB'a indiriyor.