### PR TITLE
Rename "autocomplete" props to "autoComplete"

### DIFF
--- a/src/scenes/ChangePassword/Form.js
+++ b/src/scenes/ChangePassword/Form.js
@@ -15,7 +15,7 @@ const ChangePasswordForm = ({isSubmitting, isValidating}) => <Form>
       <TextField
         type="password"
         name="password"
-        autocomplete="password"
+        autoComplete="password"
       />
     </Box>
 

--- a/src/scenes/Settings/Form.js
+++ b/src/scenes/Settings/Form.js
@@ -18,7 +18,7 @@ const SettingsForm = ({isSubmitting, isValidating}) => <Form>
     <Box>
       <TextField
         name="bio"
-        autocomplete="bio"
+        autoComplete="bio"
         multiLine={true}
       />
     </Box>
@@ -26,21 +26,21 @@ const SettingsForm = ({isSubmitting, isValidating}) => <Form>
     <Box mt={20}>
       <TextField
         name="name"
-        autocomplete="name"
+        autoComplete="name"
       />
     </Box>
 
     <Box mt={20}>
       <TextField
         name="username"
-        autocomplete="username"
+        autoComplete="username"
       />
     </Box>
 
     <Box mt={20}>
       <TextField
         name="email"
-        autocomplete="email"
+        autoComplete="email"
       />
     </Box>
 
@@ -48,7 +48,7 @@ const SettingsForm = ({isSubmitting, isValidating}) => <Form>
       <TextField
         type="password"
         name="password"
-        autocomplete="password"
+        autoComplete="password"
       />
     </Box>
 

--- a/src/scenes/SignIn/Form.js
+++ b/src/scenes/SignIn/Form.js
@@ -31,7 +31,7 @@ const SignInForm = ({
           <TextField
             type='password'
             name='password'
-            autocomplete='current-password'
+            autoComplete='current-password'
           />
         </Box>
 

--- a/src/scenes/SignUp/Form.js
+++ b/src/scenes/SignUp/Form.js
@@ -26,7 +26,7 @@ const SignupForm = ({onSignInClick, isSubmitting, isValidating}) => <Form>
       <Box mt={15}>
         <TextField
           name="email"
-          autocomplete="email"
+          autoComplete="email"
         />
       </Box>
 
@@ -34,7 +34,7 @@ const SignupForm = ({onSignInClick, isSubmitting, isValidating}) => <Form>
         <TextField
           type="name"
           name="name"
-          autocomplete="name"
+          autoComplete="name"
         />
       </Box>
 
@@ -42,7 +42,7 @@ const SignupForm = ({onSignInClick, isSubmitting, isValidating}) => <Form>
         <TextField
           type="password"
           name="password"
-          autocomplete="current-password"
+          autoComplete="current-password"
         />
       </Box>
     </Flex>


### PR DESCRIPTION
As required by React.

Those were actually fine but I mistakenly renamed them from
"autoComplete" to "autocomplete" earlier, hence this fix.